### PR TITLE
build: increase timeout for e2e tests

### DIFF
--- a/.github/workflows/cyclic-browser-test.yml
+++ b/.github/workflows/cyclic-browser-test.yml
@@ -18,7 +18,7 @@ jobs:
       options: --ipc=host --user 1001 # see [firefox restriction](https://github.com/cypress-io/github-action#firefox)
       env:
         VUE_APP_BACKEND_TYPE: 'testVolatile'
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/.github/workflows/cyclic-os-test.yml
+++ b/.github/workflows/cyclic-os-test.yml
@@ -15,7 +15,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     env:
       VUE_APP_BACKEND_TYPE: 'testVolatile'
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1


### PR DESCRIPTION
several failed cron tests over the last weeks because of the 15min limit, bump it to 20